### PR TITLE
Add swagger endpoint

### DIFF
--- a/Rinkudesu.Services.Links/Rinkudesu.Services.Links.Repositories/QueryModels/LinkListQueryModel.cs
+++ b/Rinkudesu.Services.Links/Rinkudesu.Services.Links.Repositories/QueryModels/LinkListQueryModel.cs
@@ -1,5 +1,4 @@
-﻿using System.ComponentModel.DataAnnotations;
-using System.Linq;
+﻿using System.Linq;
 using Microsoft.EntityFrameworkCore;
 using Rinkudesu.Services.Links.Models;
 

--- a/Rinkudesu.Services.Links/Rinkudesu.Services.Links.Repositories/QueryModels/LinkListQueryModel.cs
+++ b/Rinkudesu.Services.Links/Rinkudesu.Services.Links.Repositories/QueryModels/LinkListQueryModel.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System.ComponentModel.DataAnnotations;
+using System.Linq;
 using Microsoft.EntityFrameworkCore;
 using Rinkudesu.Services.Links.Models;
 

--- a/Rinkudesu.Services.Links/Rinkudesu.Services.Links/Controllers/LinksController.cs
+++ b/Rinkudesu.Services.Links/Rinkudesu.Services.Links/Controllers/LinksController.cs
@@ -14,6 +14,9 @@ using Rinkudesu.Services.Links.Repositories.QueryModels;
 
 namespace Rinkudesu.Services.Links.Controllers
 {
+    /// <summary>
+    /// Links controller responsible for basic management of <see cref="Link"/> objects
+    /// </summary>
     [ExcludeFromCodeCoverage]
     [ApiController]
     [Route("api/[controller]")]
@@ -23,7 +26,9 @@ namespace Rinkudesu.Services.Links.Controllers
         private readonly ILinkRepository _repository;
         private readonly ILogger _logger;
 
+#pragma warning disable 1591
         public LinksController(ILinkRepository repository, IMapper mapper, ILogger<LinksController> logger)
+#pragma warning restore 1591
         {
             _mapper = mapper;
             _repository = repository;

--- a/Rinkudesu.Services.Links/Rinkudesu.Services.Links/DataTransferObjects/LinkDto.cs
+++ b/Rinkudesu.Services.Links/Rinkudesu.Services.Links/DataTransferObjects/LinkDto.cs
@@ -4,6 +4,9 @@ using Rinkudesu.Services.Links.Models;
 
 namespace Rinkudesu.Services.Links.DataTransferObjects
 {
+    /// <summary>
+    /// Data transfer object to send and receive <see cref="Link"/> objects
+    /// </summary>
     [ExcludeFromCodeCoverage]
     public class LinkDto
     {

--- a/Rinkudesu.Services.Links/Rinkudesu.Services.Links/DataTransferObjects/LinkDto.cs
+++ b/Rinkudesu.Services.Links/Rinkudesu.Services.Links/DataTransferObjects/LinkDto.cs
@@ -7,13 +7,37 @@ namespace Rinkudesu.Services.Links.DataTransferObjects
     [ExcludeFromCodeCoverage]
     public class LinkDto
     {
+        /// <summary>
+        /// Link id
+        /// </summary>
         public Guid Id { get; set; }
+        /// <summary>
+        /// URL the link is pointing to
+        /// </summary>
         public string LinkUrl { get; set; } = string.Empty;
+        /// <summary>
+        /// Title of the link
+        /// </summary>
         public string Title { get; set; } = string.Empty;
+        /// <summary>
+        /// Description of the link
+        /// </summary>
         public string? Description { get; set; }
+        /// <summary>
+        /// Privacy configuration of the link
+        /// </summary>
         public Link.LinkPrivacyOptions PrivacyOptions { get; set; }
+        /// <summary>
+        /// Date the link was created at
+        /// </summary>
         public DateTime CreationDate { get; set; }
+        /// <summary>
+        /// Date the link was last modified at
+        /// </summary>
         public DateTime LastUpdate { get; set; }
+        /// <summary>
+        /// Id of a user creating the link
+        /// </summary>
         public string CreatingUserId { get; set; } = string.Empty;
     }
 }

--- a/Rinkudesu.Services.Links/Rinkudesu.Services.Links/DataTransferObjects/LinkMappingProfile.cs
+++ b/Rinkudesu.Services.Links/Rinkudesu.Services.Links/DataTransferObjects/LinkMappingProfile.cs
@@ -1,6 +1,7 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using AutoMapper;
 using Rinkudesu.Services.Links.Models;
+#pragma warning disable 1591
 
 namespace Rinkudesu.Services.Links.DataTransferObjects
 {

--- a/Rinkudesu.Services.Links/Rinkudesu.Services.Links/InputArguments.cs
+++ b/Rinkudesu.Services.Links/Rinkudesu.Services.Links/InputArguments.cs
@@ -1,6 +1,7 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using CommandLine;
 using Serilog;
+#pragma warning disable 1591
 
 namespace Rinkudesu.Services.Links
 {

--- a/Rinkudesu.Services.Links/Rinkudesu.Services.Links/Migrations/20210819191908_InitialMigration.Designer.cs
+++ b/Rinkudesu.Services.Links/Rinkudesu.Services.Links/Migrations/20210819191908_InitialMigration.Designer.cs
@@ -8,6 +8,8 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Rinkudesu.Services.Links.Data;
 
+#pragma warning disable CS1591
+
 namespace Rinkudesu.Services.Links.Migrations
 {
     [DbContext(typeof(LinkDbContext))]

--- a/Rinkudesu.Services.Links/Rinkudesu.Services.Links/Migrations/20210819191908_InitialMigration.cs
+++ b/Rinkudesu.Services.Links/Rinkudesu.Services.Links/Migrations/20210819191908_InitialMigration.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using Microsoft.EntityFrameworkCore.Migrations;
 
+#pragma warning disable CS1591
+
 namespace Rinkudesu.Services.Links.Migrations
 {
     public partial class InitialMigration : Migration

--- a/Rinkudesu.Services.Links/Rinkudesu.Services.Links/Program.cs
+++ b/Rinkudesu.Services.Links/Rinkudesu.Services.Links/Program.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.Hosting;
 using Serilog;
 using Serilog.Exceptions;
 using Serilog.Formatting.Compact;
+#pragma warning disable 1591
 
 namespace Rinkudesu.Services.Links
 {

--- a/Rinkudesu.Services.Links/Rinkudesu.Services.Links/Rinkudesu.Services.Links.csproj
+++ b/Rinkudesu.Services.Links/Rinkudesu.Services.Links/Rinkudesu.Services.Links.csproj
@@ -12,6 +12,16 @@
         <Company>Rinkudesu</Company>
     </PropertyGroup>
 
+    <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
+      <DocumentationFile>bin\Debug\Rinkudesu.Services.Links.xml</DocumentationFile>
+    </PropertyGroup>
+
+    <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+      <DebugSymbols>false</DebugSymbols>
+      <DebugType>none</DebugType>
+      <DocumentationFile>bin\Release\Rinkudesu.Services.Links.xml</DocumentationFile>
+    </PropertyGroup>
+
     <ItemGroup>
       <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="8.1.1" />
       <PackageReference Include="CommandLineParser" Version="2.8.0" />
@@ -25,6 +35,9 @@
       <PackageReference Include="Serilog.Exceptions" Version="7.0.0" />
       <PackageReference Include="Serilog.Extensions.Hosting" Version="4.1.2" />
       <PackageReference Include="Serilog.Sinks.Console" Version="4.0.0" />
+      <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="6.1.5" />
+      <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.1.5" />
+      <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="6.1.5" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Rinkudesu.Services.Links/Rinkudesu.Services.Links/Rinkudesu.Services.Links.csproj
+++ b/Rinkudesu.Services.Links/Rinkudesu.Services.Links/Rinkudesu.Services.Links.csproj
@@ -20,6 +20,7 @@
       <DebugSymbols>false</DebugSymbols>
       <DebugType>none</DebugType>
       <DocumentationFile>bin\Release\Rinkudesu.Services.Links.xml</DocumentationFile>
+      <NoWarn>1701;1702;1591</NoWarn>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Rinkudesu.Services.Links/Rinkudesu.Services.Links/Startup.cs
+++ b/Rinkudesu.Services.Links/Rinkudesu.Services.Links/Startup.cs
@@ -15,6 +15,7 @@ using Rinkudesu.Services.Links.DataTransferObjects;
 using Rinkudesu.Services.Links.Repositories;
 using Rinkudesu.Services.Links.Utilities;
 using Serilog;
+#pragma warning disable 1591
 
 namespace Rinkudesu.Services.Links
 {

--- a/Rinkudesu.Services.Links/Rinkudesu.Services.Links/Startup.cs
+++ b/Rinkudesu.Services.Links/Rinkudesu.Services.Links/Startup.cs
@@ -1,10 +1,15 @@
+using System;
 using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Reflection;
+using System.Text.Json.Serialization;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.OpenApi.Models;
 using Rinkudesu.Services.Links.Data;
 using Rinkudesu.Services.Links.DataTransferObjects;
 using Rinkudesu.Services.Links.Repositories;
@@ -40,7 +45,19 @@ namespace Rinkudesu.Services.Links
                 options.EnableSensitiveDataLogging();
 #endif
             });
-            services.AddControllers();
+            services.AddControllers()
+                .AddJsonOptions(o => o.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter()));
+            services.AddSwaggerGen(c => {
+                c.SwaggerDoc("v1", new OpenApiInfo
+                {
+                    Version = "v1",
+                    Title = "Link management API",
+                    Description = "API to manage link objects"
+                });
+                var xmlName = $"{Assembly.GetExecutingAssembly().GetName().Name}.xml";
+                var xmlPath = AppContext.BaseDirectory;
+                c.IncludeXmlComments(Path.Combine(xmlPath, xmlName));
+            });
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
@@ -54,6 +71,11 @@ namespace Rinkudesu.Services.Links
             app.UseHttpsRedirection();
 
             app.UseSerilogRequestLogging();
+
+            app.UseSwagger();
+            app.UseSwaggerUI(c => {
+                c.SwaggerEndpoint("/swagger/v1/swagger.json", "Links API V1");
+            });
 
             app.UseRouting();
 

--- a/ThirdPartyLicences.md
+++ b/ThirdPartyLicences.md
@@ -263,3 +263,27 @@ TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
 PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND Npgsql
 HAS NO OBLIGATIONS TO PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS,
 OR MODIFICATIONS.
+
+# [Swashbuckle](https://github.com/domaindrivendev/Swashbuckle.AspNetCore/blob/master/LICENSE)
+
+The MIT License (MIT)
+
+Copyright (c) 2016 Richard Morris
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
Enables swagger endpoint at /swagger when a flag is specified.

Because the xml doc generation flag is now enabled in the compiler, any public entity with no xml doc generates a warning when compiling as DEBUG unless explicitely disabled.
On RELEASE the warnings are ignored so as not to generate clutter in CI actions.

Some legitimate documentation was missing, so I've added it.

Enums in controller arguments are now automatically parsed from strings in queries and bodies.

Closes #11
