### PR TITLE
Add kestrel hosting configuration

### DIFF
--- a/Rinkudesu.Services.Links/Rinkudesu.Services.Links/Program.cs
+++ b/Rinkudesu.Services.Links/Rinkudesu.Services.Links/Program.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Security.Authentication;
+using System.Security.Cryptography.X509Certificates;
 using CommandLine;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Hosting;
@@ -64,6 +66,14 @@ namespace Rinkudesu.Services.Links
                         .Enrich.WithProperty("ApplicationName", context.HostingEnvironment.ApplicationName)
                         .Enrich.WithExceptionDetails();
                 })
-                .ConfigureWebHostDefaults(webBuilder => { webBuilder.UseStartup<Startup>(); });
+                .ConfigureWebHostDefaults(webBuilder => {
+                    webBuilder.UseStartup<Startup>();
+                    webBuilder.UseKestrel((context, serverOptions) => {
+                        serverOptions.ConfigureHttpsDefaults(https => {
+                            https.SslProtocols = SslProtocols.Tls12 | SslProtocols.Tls13;
+                            https.ServerCertificate = new X509Certificate2("cert.pfx");
+                        });
+                    });
+                });
     }
 }

--- a/Rinkudesu.Services.Links/Rinkudesu.Services.Links/docker-compose.yml
+++ b/Rinkudesu.Services.Links/Rinkudesu.Services.Links/docker-compose.yml
@@ -14,7 +14,11 @@ services:
       - postgres
     ports:
       - "80:80"
+#      - "443:443"
     environment:
       RINKU_LINKS_CONNECTIONSTRING: "Server=postgres;Port=5432;Database=rinku-links;User Id=postgres;Password=postgres;"
+#      ASPNETCORE_URLS: "http://0.0.0.0:80;https://0.0.0.0:443"
+#    volumes:
+#      - ./cert.pfx:/app/cert.pfx:ro
     command:
       - "--applyMigrations"


### PR DESCRIPTION
Well, all of this should be better documented somewhere once (or rather, if) the actual documentation is created.
For now, there are comments in the docker-compose that clearly indicate what should be done.

Only .pfx certificates are accepted as of now, because I can't be bothered to spend a lot of time trying to get pem/crt to work with Kestrel.

Closes #10
