### PR TITLE
Send messages to kafka on link events

### DIFF
--- a/Rinkudesu.Services.Links/Rinkudesu.Services.Links.Data/LinkDbContextExtensions.cs
+++ b/Rinkudesu.Services.Links/Rinkudesu.Services.Links.Data/LinkDbContextExtensions.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Data;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore.Storage;
+
+namespace Rinkudesu.Services.Links.Data;
+
+public static class LinkDbContextExtensions
+{
+    public static async Task<TResult> ExecuteInTransaction<TState, TResult>(this LinkDbContext context, TState state, Func<TState, CancellationToken, Task<TResult>> action, IsolationLevel isolationLevel = IsolationLevel.ReadCommitted, CancellationToken cancellationToken = default)
+    {
+        var executionStrategy = context.Database.CreateExecutionStrategy();
+        return await executionStrategy.ExecuteInTransactionAsync(state, action, (_, _) => Task.FromResult(false), isolationLevel, cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/Rinkudesu.Services.Links/Rinkudesu.Services.Links.Data/Rinkudesu.Services.Links.Data.csproj
+++ b/Rinkudesu.Services.Links/Rinkudesu.Services.Links.Data/Rinkudesu.Services.Links.Data.csproj
@@ -17,6 +17,7 @@
 
     <ItemGroup>
       <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.8" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="6.0.8" />
     </ItemGroup>
 
 </Project>

--- a/Rinkudesu.Services.Links/Rinkudesu.Services.Links.MessageQueues/Constants.cs
+++ b/Rinkudesu.Services.Links/Rinkudesu.Services.Links.MessageQueues/Constants.cs
@@ -1,0 +1,10 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace Rinkudesu.Services.Links.MessageQueues;
+
+[ExcludeFromCodeCoverage]
+internal static class Constants
+{
+    public const string TOPIC_TICKET_NEW = "links-new";
+    public const string TOPIC_TICKET_DELETE = "links-delete";
+}

--- a/Rinkudesu.Services.Links/Rinkudesu.Services.Links.MessageQueues/GlobalSuppressions.cs
+++ b/Rinkudesu.Services.Links/Rinkudesu.Services.Links.MessageQueues/GlobalSuppressions.cs
@@ -1,0 +1,5 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+
+[assembly: CLSCompliant(false)]
+[assembly: SuppressMessage("Design", "CA1062:Validate arguments of public methods", Scope = "module")]

--- a/Rinkudesu.Services.Links/Rinkudesu.Services.Links.MessageQueues/KafkaProducerExtensions.cs
+++ b/Rinkudesu.Services.Links/Rinkudesu.Services.Links.MessageQueues/KafkaProducerExtensions.cs
@@ -1,0 +1,16 @@
+using System.Diagnostics.CodeAnalysis;
+using Rinkudesu.Kafka.Dotnet.Base;
+using Rinkudesu.Services.Links.MessageQueues.Messages;
+using Rinkudesu.Services.Links.Models;
+
+namespace Rinkudesu.Services.Links.MessageQueues;
+
+[ExcludeFromCodeCoverage]
+public static class KafkaProducerExtensions
+{
+    public static async Task ProduceNewLink(this IKafkaProducer producer, Link link, CancellationToken cancellationToken = default)
+        => await producer.Produce(Constants.TOPIC_TICKET_NEW, new LinkCreatedMessage(link.Id, link.CreatingUserId), cancellationToken);
+
+    public static async Task ProduceDeletedLink(this IKafkaProducer producer, Link link, CancellationToken cancellationToken = default)
+        => await producer.Produce(Constants.TOPIC_TICKET_DELETE, new LinkDeletedMessage(link.Id), cancellationToken);
+}

--- a/Rinkudesu.Services.Links/Rinkudesu.Services.Links.MessageQueues/KafkaProducerExtensions.cs
+++ b/Rinkudesu.Services.Links/Rinkudesu.Services.Links.MessageQueues/KafkaProducerExtensions.cs
@@ -9,8 +9,8 @@ namespace Rinkudesu.Services.Links.MessageQueues;
 public static class KafkaProducerExtensions
 {
     public static async Task ProduceNewLink(this IKafkaProducer producer, Link link, CancellationToken cancellationToken = default)
-        => await producer.Produce(Constants.TOPIC_TICKET_NEW, new LinkCreatedMessage(link.Id, link.CreatingUserId), cancellationToken);
+        => await producer.Produce(Constants.TOPIC_TICKET_NEW, new LinkCreatedMessage(link.Id, link.CreatingUserId), cancellationToken).ConfigureAwait(false);
 
     public static async Task ProduceDeletedLink(this IKafkaProducer producer, Link link, CancellationToken cancellationToken = default)
-        => await producer.Produce(Constants.TOPIC_TICKET_DELETE, new LinkDeletedMessage(link.Id), cancellationToken);
+        => await producer.Produce(Constants.TOPIC_TICKET_DELETE, new LinkDeletedMessage(link.Id), cancellationToken).ConfigureAwait(false);
 }

--- a/Rinkudesu.Services.Links/Rinkudesu.Services.Links.MessageQueues/Messages/LinkCreatedMessage.cs
+++ b/Rinkudesu.Services.Links/Rinkudesu.Services.Links.MessageQueues/Messages/LinkCreatedMessage.cs
@@ -1,0 +1,23 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json.Serialization;
+
+namespace Rinkudesu.Services.Links.MessageQueues.Messages;
+
+/// <summary>
+/// Message sent when a new link is created for a user.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public class LinkCreatedMessage : LinkMessage
+{
+    [JsonPropertyName("user_id")]
+    public Guid UserId { get; set; }
+
+    public LinkCreatedMessage()
+    {
+    }
+
+    public LinkCreatedMessage(Guid linkId, Guid userId) : base(linkId)
+    {
+        UserId = userId;
+    }
+}

--- a/Rinkudesu.Services.Links/Rinkudesu.Services.Links.MessageQueues/Messages/LinkDeletedMessage.cs
+++ b/Rinkudesu.Services.Links/Rinkudesu.Services.Links.MessageQueues/Messages/LinkDeletedMessage.cs
@@ -1,0 +1,18 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace Rinkudesu.Services.Links.MessageQueues.Messages;
+
+/// <summary>
+/// Message sent when a link is deleted.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public class LinkDeletedMessage : LinkMessage
+{
+    public LinkDeletedMessage()
+    {
+    }
+
+    public LinkDeletedMessage(Guid linkId) : base(linkId)
+    {
+    }
+}

--- a/Rinkudesu.Services.Links/Rinkudesu.Services.Links.MessageQueues/Messages/LinkMessage.cs
+++ b/Rinkudesu.Services.Links/Rinkudesu.Services.Links.MessageQueues/Messages/LinkMessage.cs
@@ -1,0 +1,24 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json.Serialization;
+using Rinkudesu.Kafka.Dotnet.Base;
+
+namespace Rinkudesu.Services.Links.MessageQueues.Messages;
+
+/// <summary>
+/// Generic message indicating a change with a link.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public abstract class LinkMessage : GenericKafkaMessage
+{
+    [JsonPropertyName("link_id")]
+    public Guid LinkId { get; set; }
+
+    protected LinkMessage()
+    {
+    }
+
+    protected LinkMessage(Guid linkId)
+    {
+        LinkId = linkId;
+    }
+}

--- a/Rinkudesu.Services.Links/Rinkudesu.Services.Links.MessageQueues/Messages/UserDeletedMessage.cs
+++ b/Rinkudesu.Services.Links/Rinkudesu.Services.Links.MessageQueues/Messages/UserDeletedMessage.cs
@@ -1,0 +1,24 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json.Serialization;
+using Rinkudesu.Kafka.Dotnet.Base;
+
+namespace Rinkudesu.Services.Links.MessageQueues.Messages;
+
+/// <summary>
+/// Message sent when a user is deleted.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public class UserDeletedMessage : GenericKafkaMessage
+{
+    [JsonPropertyName("user_id")]
+    public Guid UserId { get; set; }
+
+    public UserDeletedMessage()
+    {
+    }
+
+    public UserDeletedMessage(Guid userId)
+    {
+        UserId = userId;
+    }
+}

--- a/Rinkudesu.Services.Links/Rinkudesu.Services.Links.MessageQueues/Rinkudesu.Services.Links.MessageQueues.csproj
+++ b/Rinkudesu.Services.Links/Rinkudesu.Services.Links.MessageQueues/Rinkudesu.Services.Links.MessageQueues.csproj
@@ -14,5 +14,9 @@
     <ItemGroup>
         <PackageReference Include="Rinkudesu.Kafka.Dotnet" Version="0.0.1" />
     </ItemGroup>
+    
+    <ItemGroup>
+      <ProjectReference Include="..\Rinkudesu.Services.Links.Models\Rinkudesu.Services.Links.Models.csproj" />
+    </ItemGroup>
 
 </Project>

--- a/Rinkudesu.Services.Links/Rinkudesu.Services.Links.MessageQueues/Rinkudesu.Services.Links.MessageQueues.csproj
+++ b/Rinkudesu.Services.Links/Rinkudesu.Services.Links.MessageQueues/Rinkudesu.Services.Links.MessageQueues.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net6.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <AnalysisMode>All</AnalysisMode>
+    </PropertyGroup>
+
+    <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    </PropertyGroup>
+    
+    <ItemGroup>
+        <PackageReference Include="Rinkudesu.Kafka.Dotnet" Version="0.0.1" />
+    </ItemGroup>
+
+</Project>

--- a/Rinkudesu.Services.Links/Rinkudesu.Services.Links.Repositories/LinkRepository.cs
+++ b/Rinkudesu.Services.Links/Rinkudesu.Services.Links.Repositories/LinkRepository.cs
@@ -124,9 +124,9 @@ namespace Rinkudesu.Services.Links.Repositories
             var state = new { context = _context, kafka = _kafkaProducer, link };
             _ = await _context.ExecuteInTransaction(state, async (localState, c) => {
                 localState.context.ClearTracked();
-                localState.context.Remove(localState.link!);
+                localState.context.Remove(localState.link);
                 await localState.context.SaveChangesAsync(c).ConfigureAwait(false);
-                await localState.kafka.ProduceDeletedLink(localState.link!, CancellationToken.None);
+                await localState.kafka.ProduceDeletedLink(localState.link, CancellationToken.None).ConfigureAwait(false);
                 return true;
             }, cancellationToken: token).ConfigureAwait(false);
         }

--- a/Rinkudesu.Services.Links/Rinkudesu.Services.Links.Repositories/Rinkudesu.Services.Links.Repositories.csproj
+++ b/Rinkudesu.Services.Links/Rinkudesu.Services.Links.Repositories/Rinkudesu.Services.Links.Repositories.csproj
@@ -13,6 +13,7 @@
 
     <ItemGroup>
       <ProjectReference Include="..\Rinkudesu.Services.Links.Data\Rinkudesu.Services.Links.Data.csproj" />
+      <ProjectReference Include="..\Rinkudesu.Services.Links.MessageQueues\Rinkudesu.Services.Links.MessageQueues.csproj" />
       <ProjectReference Include="..\Rinkudesu.Services.Links.Models\Rinkudesu.Services.Links.Models.csproj" />
     </ItemGroup>
 

--- a/Rinkudesu.Services.Links/Rinkudesu.Services.Links.Tests/LinkRepositoryTests.cs
+++ b/Rinkudesu.Services.Links/Rinkudesu.Services.Links.Tests/LinkRepositoryTests.cs
@@ -1,8 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Rinkudesu.Kafka.Dotnet.Base;
+using Rinkudesu.Services.Links.MessageQueues.Messages;
 using Rinkudesu.Services.Links.Models;
 using Rinkudesu.Services.Links.Repositories;
 using Rinkudesu.Services.Links.Repositories.Exceptions;
@@ -33,7 +37,9 @@ namespace Rinkudesu.Services.Links.Tests
 
         private LinkRepository CreateRepository()
         {
-            return new LinkRepository(_context, new NullLogger<LinkRepository>());
+            var mockKafkaHandler = new Mock<IKafkaProducer>();
+            mockKafkaHandler.Setup(k => k.Produce(It.IsAny<string>(), It.IsAny<LinkMessage>(), It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+            return new LinkRepository(_context, new NullLogger<LinkRepository>(), mockKafkaHandler.Object);
         }
 
         [Fact]

--- a/Rinkudesu.Services.Links/Rinkudesu.Services.Links.Tests/Rinkudesu.Services.Links.Tests.csproj
+++ b/Rinkudesu.Services.Links/Rinkudesu.Services.Links.Tests/Rinkudesu.Services.Links.Tests.csproj
@@ -21,6 +21,7 @@
         <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.8" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.8" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
+        <PackageReference Include="Moq" Version="4.18.2" />
         <PackageReference Include="xunit" Version="2.4.2" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Rinkudesu.Services.Links/Rinkudesu.Services.Links.sln
+++ b/Rinkudesu.Services.Links/Rinkudesu.Services.Links.sln
@@ -14,6 +14,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Rinkudesu.Services.Links.Da
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Rinkudesu.Services.Links.HealthChecks", "Rinkudesu.Services.Links.HealthChecks\Rinkudesu.Services.Links.HealthChecks.csproj", "{E43C4BCB-2BB1-4602-A5BC-AB7216F679E2}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Rinkudesu.Services.Links.MessageQueues", "Rinkudesu.Services.Links.MessageQueues\Rinkudesu.Services.Links.MessageQueues.csproj", "{21668503-23C6-4AC2-BA23-1E0843AD99A0}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -48,5 +50,9 @@ Global
 		{E43C4BCB-2BB1-4602-A5BC-AB7216F679E2}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E43C4BCB-2BB1-4602-A5BC-AB7216F679E2}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E43C4BCB-2BB1-4602-A5BC-AB7216F679E2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{21668503-23C6-4AC2-BA23-1E0843AD99A0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{21668503-23C6-4AC2-BA23-1E0843AD99A0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{21668503-23C6-4AC2-BA23-1E0843AD99A0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{21668503-23C6-4AC2-BA23-1E0843AD99A0}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/Rinkudesu.Services.Links/Rinkudesu.Services.Links/Program.cs
+++ b/Rinkudesu.Services.Links/Rinkudesu.Services.Links/Program.cs
@@ -18,6 +18,8 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.IdentityModel.Tokens;
 using Microsoft.OpenApi.Models;
+using Rinkudesu.Kafka.Dotnet;
+using Rinkudesu.Kafka.Dotnet.Base;
 using Rinkudesu.Services.Links;
 using Rinkudesu.Services.Links.Data;
 using Rinkudesu.Services.Links.DataTransferObjects;
@@ -100,6 +102,7 @@ return 0;
 
 void ConfigureServices(IServiceCollection services)
 {
+    SetupKafka(services);
     services.AddScoped<ILinkRepository, LinkRepository>();
     services.AddAutoMapper(typeof(LinkMappingProfile));
     services.AddScoped<ISharedLinkRepository, SharedLinkRepository>();
@@ -192,4 +195,12 @@ static void ApplyMigrations(IApplicationBuilder app)
     using var scope = app.ApplicationServices.GetRequiredService<IServiceScopeFactory>().CreateScope();
     using var context = scope.ServiceProvider.GetRequiredService<LinkDbContext>();
     context.Database.Migrate();
+}
+
+static void SetupKafka(IServiceCollection serviceCollection)
+{
+    //todo: load those in a better way
+    var kafkaConfig = new KafkaConfigurationProvider("localhost:9092", null, null, Assembly.GetExecutingAssembly().FullName!);
+    serviceCollection.AddSingleton(kafkaConfig);
+    serviceCollection.AddSingleton<IKafkaProducer, KafkaProducer>();
 }

--- a/Rinkudesu.Services.Links/Rinkudesu.Services.Links/Program.cs
+++ b/Rinkudesu.Services.Links/Rinkudesu.Services.Links/Program.cs
@@ -199,8 +199,7 @@ static void ApplyMigrations(IApplicationBuilder app)
 
 static void SetupKafka(IServiceCollection serviceCollection)
 {
-    //todo: load those in a better way
-    var kafkaConfig = new KafkaConfigurationProvider("localhost:9092", null, null, Assembly.GetExecutingAssembly().FullName!);
+    var kafkaConfig = KafkaConfigurationProvider.ReadFromEnv();
     serviceCollection.AddSingleton(kafkaConfig);
     serviceCollection.AddSingleton<IKafkaProducer, KafkaProducer>();
 }

--- a/Rinkudesu.Services.Links/Rinkudesu.Services.Links/Properties/launchSettings.json
+++ b/Rinkudesu.Services.Links/Rinkudesu.Services.Links/Properties/launchSettings.json
@@ -10,7 +10,10 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "RINKUDESU_AUTHORITY": "http://localhost:8080/auth/realms/rinkudesu",
-        "RINKU_LINKS_CONNECTIONSTRING": "Server=127.0.0.1;Port=5432;Database=rinku-links;User Id=postgres;Password=postgres;"
+        "RINKU_LINKS_CONNECTIONSTRING": "Server=127.0.0.1;Port=5432;Database=rinku-links;User Id=postgres;Password=postgres;",
+        "RINKU_KAFKA_ADDRESS": "localhost:9092",
+        "RINKU_KAFKA_CLIENT_ID": "rinkudesu-links",
+        "RINKU_KAFKA_CONSUMER_GROUP_ID": "rinkudesu-links"
       }
     }
   }

--- a/Rinkudesu.Services.Links/Rinkudesu.Services.Links/Rinkudesu.Services.Links.csproj
+++ b/Rinkudesu.Services.Links/Rinkudesu.Services.Links/Rinkudesu.Services.Links.csproj
@@ -48,6 +48,7 @@
 
     <ItemGroup>
       <ProjectReference Include="..\Rinkudesu.Services.Links.HealthChecks\Rinkudesu.Services.Links.HealthChecks.csproj" />
+      <ProjectReference Include="..\Rinkudesu.Services.Links.MessageQueues\Rinkudesu.Services.Links.MessageQueues.csproj" />
       <ProjectReference Include="..\Rinkudesu.Services.Links.Models\Rinkudesu.Services.Links.Models.csproj" />
       <ProjectReference Include="..\Rinkudesu.Services.Links.Repositories\Rinkudesu.Services.Links.Repositories.csproj" />
       <ProjectReference Include="..\Rinkudesu.Services.Links.Utilities\Rinkudesu.Services.Links.Utilities.csproj" />

--- a/Rinkudesu.Services.Links/Rinkudesu.Services.Links/docker-compose.yml
+++ b/Rinkudesu.Services.Links/Rinkudesu.Services.Links/docker-compose.yml
@@ -18,6 +18,9 @@ services:
     environment:
       RINKU_LINKS_CONNECTIONSTRING: "Server=postgres;Port=5432;Database=rinku-links;User Id=postgres;Password=postgres;"
       RINKUDESU_AUTHORITY: "https://<hostname-of-keycloak-instance>/auth/realms/rinkudesu"
+      RINKU_KAFKA_ADDRESS: "<hostname-of-kafka>:9092"
+      RINKU_KAFKA_CLIENT_ID: "rinkudesu-links"
+      RINKU_KAFKA_CONSUMER_GROUP_ID: "rinkudesu-links"
 #      ASPNETCORE_URLS: "http://0.0.0.0:80;https://0.0.0.0:443"
 #    volumes:
 #      - ./cert.pfx:/app/cert.pfx:ro


### PR DESCRIPTION
Closes #85

Adds publishing messages to Kafka on link creation and deletion.
Safety checks are added so that if the publish fails, the database action is reversed, and if the database action fails, the message is not published at all.
