### PR TITLE
Add the ability to skip/take links list

### DIFF
--- a/Rinkudesu.Services.Links/Rinkudesu.Services.Links.Repositories/QueryModels/LinkListQueryModel.cs
+++ b/Rinkudesu.Services.Links/Rinkudesu.Services.Links.Repositories/QueryModels/LinkListQueryModel.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Rinkudesu.Services.Links.Models;
@@ -47,6 +48,11 @@ namespace Rinkudesu.Services.Links.Repositories.QueryModels
         [SuppressMessage("Performance", "CA1819:Properties should not return arrays")]
         public Guid[]? TagIds { get; set; }
 
+        [Range(0, int.MaxValue)]
+        public int? Skip { get; set; }
+        [Range(0, int.MaxValue)]
+        public int? Take { get; set; }
+
         public IQueryable<Link> ApplyQueryModel(IQueryable<Link> links, IEnumerable<Guid>? idsLimit = null)
         {
             SanitizeModel();
@@ -54,6 +60,7 @@ namespace Rinkudesu.Services.Links.Repositories.QueryModels
             links = FilterUrlContains(links);
             links = FilterTitleContains(links);
             links = FilterVisibility(links);
+            links = SkipTake(links);
             links = SortLinks(links);
 
             if (idsLimit is not null)
@@ -110,6 +117,19 @@ namespace Rinkudesu.Services.Links.Repositories.QueryModels
             if (!ShowPublic)
             {
                 links = links.Where(l => l.PrivacyOptions != Link.LinkPrivacyOptions.Public);
+            }
+            return links;
+        }
+
+        public IQueryable<Link> SkipTake(IQueryable<Link> links)
+        {
+            if (Skip.HasValue)
+            {
+                links = links.Skip(Skip.Value);
+            }
+            if (Take.HasValue)
+            {
+                links = links.Take(Take.Value);
             }
             return links;
         }

--- a/Rinkudesu.Services.Links/Rinkudesu.Services.Links.Tests/LinkListQueryModelTests.cs
+++ b/Rinkudesu.Services.Links/Rinkudesu.Services.Links.Tests/LinkListQueryModelTests.cs
@@ -251,7 +251,7 @@ namespace Rinkudesu.Services.Links.Tests
             var sortedLinks = testLinks.OrderBy(l => l.Title).ToList();
             for (int i = 0; i < testLinks.Count; i++)
             {
-                Assert.Equal(sortedLinks[i].Id, result[i].Id);
+                Assert.Equal(sortedLinks[i].Title, result[i].Title);
             }
         }
 
@@ -266,7 +266,7 @@ namespace Rinkudesu.Services.Links.Tests
             var sortedLinks = testLinks.OrderByDescending(l => l.Title).ToList();
             for (int i = 0; i < testLinks.Count; i++)
             {
-                Assert.Equal(sortedLinks[i].Id, result[i].Id);
+                Assert.Equal(sortedLinks[i].Title, result[i].Title);
             }
         }
 
@@ -281,7 +281,7 @@ namespace Rinkudesu.Services.Links.Tests
             var sortedLinks = testLinks.OrderBy(l => l.LinkUrl).ToList();
             for (int i = 0; i < testLinks.Count; i++)
             {
-                Assert.Equal(sortedLinks[i].Id, result[i].Id);
+                Assert.Equal(sortedLinks[i].Title, result[i].Title);
             }
         }
 
@@ -296,7 +296,7 @@ namespace Rinkudesu.Services.Links.Tests
             var sortedLinks = testLinks.OrderByDescending(l => l.LinkUrl).ToList();
             for (int i = 0; i < testLinks.Count; i++)
             {
-                Assert.Equal(sortedLinks[i].Id, result[i].Id);
+                Assert.Equal(sortedLinks[i].Title, result[i].Title);
             }
         }
 
@@ -311,7 +311,7 @@ namespace Rinkudesu.Services.Links.Tests
             var sortedLinks = testLinks.OrderBy(l => l.CreationDate).ToList();
             for (int i = 0; i < testLinks.Count; i++)
             {
-                Assert.Equal(sortedLinks[i].Id, result[i].Id);
+                Assert.Equal(sortedLinks[i].Title, result[i].Title);
             }
         }
 
@@ -326,7 +326,7 @@ namespace Rinkudesu.Services.Links.Tests
             var sortedLinks = testLinks.OrderByDescending(l => l.CreationDate).ToList();
             for (int i = 0; i < testLinks.Count; i++)
             {
-                Assert.Equal(sortedLinks[i].Id, result[i].Id);
+                Assert.Equal(sortedLinks[i].Title, result[i].Title);
             }
         }
 
@@ -341,7 +341,7 @@ namespace Rinkudesu.Services.Links.Tests
             var sortedLinks = testLinks.OrderBy(l => l.LastUpdate).ToList();
             for (int i = 0; i < testLinks.Count; i++)
             {
-                Assert.Equal(sortedLinks[i].Id, result[i].Id);
+                Assert.Equal(sortedLinks[i].Title, result[i].Title);
             }
         }
 
@@ -356,7 +356,7 @@ namespace Rinkudesu.Services.Links.Tests
             var sortedLinks = testLinks.OrderByDescending(l => l.LastUpdate).ToList();
             for (int i = 0; i < testLinks.Count; i++)
             {
-                Assert.Equal(sortedLinks[i].Id, result[i].Id);
+                Assert.Equal(sortedLinks[i].Title, result[i].Title);
             }
         }
 
@@ -371,7 +371,7 @@ namespace Rinkudesu.Services.Links.Tests
             var sortedLinks = testLinks.OrderBy(l => l.Id).ToList();
             for (int i = 0; i < testLinks.Count; i++)
             {
-                Assert.Equal(sortedLinks[i].Id, result[i].Id);
+                Assert.Equal(sortedLinks[i].Title, result[i].Title);
             }
         }
     }

--- a/Rinkudesu.Services.Links/Rinkudesu.Services.Links.Tests/LinkListQueryModelTests.cs
+++ b/Rinkudesu.Services.Links/Rinkudesu.Services.Links.Tests/LinkListQueryModelTests.cs
@@ -374,5 +374,22 @@ namespace Rinkudesu.Services.Links.Tests
                 Assert.Equal(sortedLinks[i].Title, result[i].Title);
             }
         }
+
+        [Fact]
+        public void LinkListQueryModelSkipTake_ValuesProvided_ReturnedCorrectCollection()
+        {
+            var testLinks = GetSortTestLinks();
+            var model = new LinkListQueryModel { Skip = 1, Take = 2 };
+
+            var result = model.SkipTake(testLinks.OrderBy(l => l.Title).AsQueryable()).ToList();
+
+            var sortedLinks = testLinks.OrderBy(l => l.Title).ToList();
+            Assert.DoesNotContain(result, l => l.Title == sortedLinks[0].Title);
+            Assert.Equal(2, result.Count);
+            for (int i = 1; i < 3; i++)
+            {
+                Assert.Equal(sortedLinks[i].Title, result[i - 1].Title);
+            }
+        }
     }
 }

--- a/Rinkudesu.Services.Links/Rinkudesu.Services.Links/Controllers/V1/LinksController.cs
+++ b/Rinkudesu.Services.Links/Rinkudesu.Services.Links/Controllers/V1/LinksController.cs
@@ -51,6 +51,7 @@ namespace Rinkudesu.Services.Links.Controllers.V1
         public async Task<ActionResult<IEnumerable<LinkDto>>> Get([FromQuery] LinkListQueryModel queryModel, [FromServices] TagsClient tagsClient)
         {
             using var scope = _logger.BeginScope("Requesting all links with query {queryModel}", queryModel);
+            if (!ModelState.IsValid) return BadRequest();
             queryModel.UserId = User.GetIdAsGuid();
             List<Guid>? byTag = null;
 


### PR DESCRIPTION
This is requred for making paginated lists in other services (for example in https://github.com/rinkudesu/rinkudesu-webui/issues/69).

As a side note, I've discovered that other tests have been comparing links by id, which was always zero in tests, so I've swapped that to comparison by `Title`.