### PR TITLE
Fix attempting to create duplicate links resulting in an error being thrown

### DIFF
--- a/Rinkudesu.Services.Links/Rinkudesu.Services.Links.Repositories/LinkRepository.cs
+++ b/Rinkudesu.Services.Links/Rinkudesu.Services.Links.Repositories/LinkRepository.cs
@@ -81,9 +81,9 @@ namespace Rinkudesu.Services.Links.Repositories
             }
             catch (DbUpdateException e)
             {
-                if (_context.Links.Any(l => l.Id == link.Id))
+                if (_context.Links.Any(l => l.LinkUrl == link.LinkUrl && l.CreatingUserId == link.CreatingUserId))
                 {
-                    _logger.LogWarning(e, "Link with id '{linkId}' already exists in the database", link.Id);
+                    _logger.LogWarning(e, "Link with with url '{url}' for user '{userId}' already exists in the database", link.LinkUrl, link.CreatingUserId.ToString());
                     throw new DataAlreadyExistsException(link.Id);
                 }
                 _logger.LogWarning(e, "Unexpected error occured while adding a new link to the database");

--- a/Rinkudesu.Services.Links/Rinkudesu.Services.Links.Tests/LinkRepositoryTests.cs
+++ b/Rinkudesu.Services.Links/Rinkudesu.Services.Links.Tests/LinkRepositoryTests.cs
@@ -111,12 +111,12 @@ namespace Rinkudesu.Services.Links.Tests
         }
 
         [Fact]
-        public async Task LinkRepositoryCreateLink_NewLinkWithDuplicateId_DataAlreadyExistsThrown()
+        public async Task LinkRepositoryCreateLink_NewLinkWithDuplicateData_DataAlreadyExistsThrown()
         {
             await PopulateLinksAsync();
             var repo = CreateRepository();
             _context.ClearTracked();
-            var link = new Link { Id = links.First().Id };
+            var link = new Link { LinkUrl = links.First().LinkUrl, CreatingUserId = links.First().CreatingUserId };
 
             await Assert.ThrowsAsync<DataAlreadyExistsException>(() => repo.CreateLinkAsync(link));
         }

--- a/Rinkudesu.Services.Links/Rinkudesu.Services.Links/Controllers/V1/LinksController.cs
+++ b/Rinkudesu.Services.Links/Rinkudesu.Services.Links/Controllers/V1/LinksController.cs
@@ -126,7 +126,7 @@ namespace Rinkudesu.Services.Links.Controllers.V1
         /// <param name="newLink"></param>
         /// <remarks>Note that id, creating user id, creation date and update date fields will be ignored, even if they are included in the request</remarks>
         /// <returns>Newly created link object</returns>
-        /// <response code="400">When object validation failed or the object already exists in the database</response>
+        /// <response code="400">When object validation failed or the object already exists in the database. If the link already exists, the phrase "Link already exists" will be returned.</response>
         /// <response code="201">When the object was created correctly</response>
         [HttpPost]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
@@ -147,7 +147,7 @@ namespace Rinkudesu.Services.Links.Controllers.V1
             }
             catch (DataAlreadyExistsException)
             {
-                return BadRequest();
+                return BadRequest("Link already exists");
             }
         }
 


### PR DESCRIPTION
This was happening because the `LinkRepository` was checking for duplicates using the `Id` field, even though the database was doing that by the url and user id fields.
Because of that, the database correctly detected the duplicate, but the repository didn't, thus throwing an unhandled error.

As a bonus this PR also adds a message being returned when duplicate link is being added.

Closes #246.